### PR TITLE
Contributors table and task distribution

### DIFF
--- a/Internal_README.md
+++ b/Internal_README.md
@@ -49,3 +49,12 @@ It is important to follow a familiar set of rules in order to be consistent with
     double precision :: manera_dos
     real*8           :: manera_tres 
     ```
+
+## Task Distribution
+- Main Program
+- Readers and Writers (I/O) &rarr; Read input file, write outputs
+- Initial Conditions &rarr; Positions (SC, BCC, FCC) and Velocities (bimodal, zero)
+- Interactions &rarr; Forces, Energies (total, V, T), Pressure, Momentum
+- Integrators &rarr; Velocity Verlet, Verlet, Euler // Thermostat
+- Simulation &rarr; PBC, MIC, boxmuller, RDF, MSD
+- Data Analysis (Python) &rarr; Stats and Visualization

--- a/README.md
+++ b/README.md
@@ -1,9 +1,21 @@
-# Project_I
+# Project I : MD Simulation of a VdW Gas
 
-## Team members
+## Task Distribution
+- Main Program &rarr;
+- Readers and Writers (I/O) &rarr;
+- Initial Conditions &rarr; Diego
+- Interactions &rarr; 
+- Integrators &rarr;
+- Simulation &rarr;
+- Data Analysis (Python) &rarr; Diego
 
-* IGNACIO PRIETO PONCE
-* EMMA VALDÉS MARTÍN
-* DIEGO ONTIVEROS CRUZ
-* MAITANE FARIñAS ARGOITIA
-* *MARC ALSINA COWIE*  (TEAM LEADER)
+<br>
+
+# Contributors
+
+|  Marc Alsina   |  Maitane Fariñas  |  Diego Ontiveros   |  Ignacio Prieto   |  Emma Valdés  |
+| -------------- | ----------------- | ------------------ | ----------------- | ------------- |
+| ![malsinac](https://github.com/malsinac.png "malsinac") | ![maitanefarinas](https://github.com/maitanefarinas.png "maitanefarinas") | ![diegonti](https://github.com/diegonti.png "diegonti") | ![Ronoh97](https://github.com/Ronoh97.png "Ronoh97") | ![evaldesmartin](https://github.com/evaldesmartin.png "evaldesmartin") |
+| [malsinac](https://github.com/malsinac)                                 | [maitanefarinas](https://github.com/maitanefarinas)| [diegonti](https://github.com/diegonti)                                  | [Ronoh97](https://github.com/Ronoh97)                                  | [emma](https://github.com/evaldesmartin)                                  |
+
+For further questions please refer to the main resposible of this project: [malsinac](https://github.com/malsinac) 


### PR DESCRIPTION
Added a more visual contributors table in the README and started the task distribution section.
Also, added a more detailed task distribution in the Internal_README to start specifying which jobs/subroutines are in each task.