### PR TITLE
Stats and Visualization (Python) and Writers Module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,8 @@ testing.o: testing.f90
 # Defined recipies:
 .PHONY: clean
 clean:
-	rm *.o *.mod
+	rm -f *.o *.mod
+	rm -f ./src/*.o ./src/*.mod
 
 .PHONY: run_serial
 run_serial:

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ COMP_R_FLAGS=#-O3 -funroll-loops -ftree-vectorize -finline-functions -flto=2 -fw
 
 # ~ LINKING ~
 all: MDEMI.x
-MDEMI.x: integrators.o readers_mod.o testing.o initialization.o main.o
+MDEMI.x: integrators.o readers_mod.o writers_mod.o testing.o initialization.o main.o
 	$(FC) $(F_FLAGS) $(COMP_D_FLAGS) $(COMP_R_FLAGS) $^ -o $@
 
 
@@ -31,7 +31,7 @@ testing.o: testing.f90
 
 readers_mod.o: readers_mod.f90
 	$(FC) $(F_FLAGS) $(COMP_D_FLAGS) $(COMP_R_FLAGS) -c $^
-	
+
 readers_mod.o: writers_mod.f90
 	$(FC) $(F_FLAGS) $(COMP_D_FLAGS) $(COMP_R_FLAGS) -c $^
 

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,9 @@ testing.o: testing.f90
 
 readers_mod.o: readers_mod.f90
 	$(FC) $(F_FLAGS) $(COMP_D_FLAGS) $(COMP_R_FLAGS) -c $^
+	
+readers_mod.o: writers_mod.f90
+	$(FC) $(F_FLAGS) $(COMP_D_FLAGS) $(COMP_R_FLAGS) -c $^
 
 integrators.o: integrators.f90 pbc.o potentials_module.o
 	$(FC) $(F_FLAGS) $(COMP_D_FLAGS) $(COMP_R_FLAGS) -c $^

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ testing.o: testing.f90
 readers_mod.o: readers_mod.f90
 	$(FC) $(F_FLAGS) $(COMP_D_FLAGS) $(COMP_R_FLAGS) -c $^
 
-readers_mod.o: writers_mod.f90
+writers_mod.o: writers_mod.f90
 	$(FC) $(F_FLAGS) $(COMP_D_FLAGS) $(COMP_R_FLAGS) -c $^
 
 integrators.o: integrators.f90 pbc.o potentials_module.o

--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -1,0 +1,248 @@
+"""
+Script to compute the statistics (mean, std and autocorrelation time) of the raw results of the simulation.
+Uses the Block Average method to compute the average <x> and the std \sigma.
+The STD vs. block size is fitted to a exponential function f(x) = a-b*exp(-x/tau).
+Returns an output file with the stats and plots of the statistichal error (STD) vs. the block size.
+
+Use with: $ python3 stats.py path start finish
+although if any arguments is not present chooses from the default 
+path, start,finish = ./plots/, 0,-1 
+
+Diego Ontiveros
+"""
+import os
+import sys
+import time as cpu_time
+import warnings
+
+import numpy as np
+import scipy as sp
+import matplotlib.pyplot as plt
+warnings.filterwarnings("ignore", category=RuntimeWarning)
+warnings.filterwarnings("ignore", category=sp.optimize.OptimizeWarning)
+
+to = cpu_time.time()
+
+###################### FUNCTION DEFINITION ######################
+
+
+def parseUserArguments(arguments):
+    """Parses the user input for the script."""
+
+    path = "./plots/"
+    start,finish = None,None
+
+    for i,arg in enumerate(arguments):
+        try: arguments[i] = int(arg)
+        except ValueError: pass
+
+    # When no inputs are given, stay with default
+    if len(arguments) == 0: pass
+
+    # When 1 argument is given see if its the path or start
+    elif len(arguments) == 1:
+        try: start = int(arguments[0])
+        except ValueError: path = arguments[0]
+
+    # When 2 arguments are given see if they are path+s or s+f
+    elif len(arguments) == 2:
+        if isinstance(arguments[0],str): path,start = arguments
+        elif isinstance(arguments[1],str): start,path = arguments
+        else: start,finish = arguments
+
+    # When 3 arguments are given see where the path is
+    elif len(arguments) == 3:
+        if isinstance(arguments[0],str): path,start,finish = arguments
+        elif isinstance(arguments[0],int): start, finish, path = arguments
+    
+    return path,start,finish
+
+
+def blockAverage(data, maxBlockSize=None):
+	"""Computes the block average of a timeseries "x", and 
+	provides error bounds for the estimated mean <x>. 
+
+	Parameters
+	--------------------
+	`data`  : Time series array of an observable X
+	`maxBlocksize` : Maximum number of observations/block
+
+	Returns
+	--------------------
+	`m_points` : Points used (observations/block) for computing averages
+	`blockVar` : Variances for each blocksize array 
+	`blockMean` : Variances for each blocksize array 	
+	"""
+ 
+	Nobs = len(data)           # total number of observations in data
+	minBlockSize = 1           # min 1 observation/block
+ 
+	if maxBlockSize is None: maxBlockSize = int(Nobs/4)   # max: 4 blocks (otherwise can't calc variance)
+  
+	# m_points = 2**n until being less of the inputed maxblocksize
+	power = np.arange(int(np.log(maxBlockSize)/np.log(2)))
+	m_points = 2**power
+
+	NumBlocks = len(m_points)   				# total number of block sizes
+
+	blockMean = np.zeros(NumBlocks)             # mean for each blocksize
+	blockVar  = np.zeros(NumBlocks)             # variance associated with each blockSize
+
+
+	# Loop for all considered blocksizes (m)
+	for k,m in enumerate(m_points):
+
+		Nblock    = int(Nobs/m)               # Number of blocks
+		obsProp   = np.zeros(Nblock)          # Container for parcelling block 
+
+		# Loop to chop datastream into blocks and take average
+		for i in range(1,Nblock+1):
+			
+			i1 = (i-1) * m
+			i2 =  i1 + m
+			obsProp[i-1] = np.mean(data[i1:i2])
+
+		blockMean[k] = np.mean(obsProp)
+		blockVar[k]  = np.var(obsProp)/(Nblock - 1)
+	
+	return m_points, blockVar, blockMean
+
+
+def plotBlockAverage(m_points,blockVar,blockMean,fit_params=None,save=True,save_name="BlockAverage.jpg",label="x"):
+	"""
+	Returns a plot of the square root of the block variance and the block means as a function of block size m.
+
+	Parameters
+	---------------
+	`m_points` : array with the number of samples/block used.
+	`blockVar` : array with the block variances gathered.
+	`blockMean` : array with the block means gathered.
+	`fit_params`: (optional) optimized parameters of the fitting function a-b*exp(-m/t).
+	`save`: (optional) Boolean to save or not the image. Defauls to True.
+	`save_name`: (optional) File name of the saved image.
+	`label` : (optional) Formatted label of the obserbable. In form: Observable(Units).
+	"""
+	# Getting label and units for the axis labels
+	observable_label = label.split("(")[0]
+	observable_units = label.split(")")[0].split("(")[-1]
+
+	fig,(ax1,ax2) = plt.subplots(1,2, figsize = (10,5))
+
+	# Plotting the STD points for each block (m)
+	ax1.scatter(m_points, np.sqrt(blockVar),marker="x",c="k",lw=1)
+
+	# Plots the fitting to the STD points
+	if fit_params is not None:
+		x = np.linspace(m_points[0],m_points[-1])
+		ax1.plot(x,fit_function(x,*fit_params),"k:",label="fit")
+
+	# Labels and Legend
+	ax1.set_xlabel('m')
+	ax1.set_ylabel(f'$\sigma_m$ ({observable_label}) ({observable_units})')
+	ax1.legend()
+
+	# Plotting the mean points for each block with the STD as errorbars
+	ax2.errorbar(m_points, blockMean, yerr=np.sqrt(blockVar),fmt="k.-",capsize=5)
+	ax2.set_ylabel(f'$\\langle${observable_label}$\\rangle$ ({observable_units})')
+	ax2.set_xlabel('m')
+
+	fig.tight_layout()
+
+	if save: fig.savefig(path+save_name,dpi=600)
+
+
+def fit(fit_function,m_points,blockSTD):
+	"""Fitting the computed block statistichal errors to the fit_function given"""
+	params,cov = sp.optimize.curve_fit(fit_function,m_points,blockSTD)
+	return params,cov
+
+def fit_function(x,a,b,tau):
+	"""Fit function for the statistichal error points."""
+	return a-b*np.exp(-x/tau)
+
+
+def write(line,file):
+	"""Prints and writes line in the terminal and output file."""
+	print(line)
+	with open(file,"a",encoding="utf-8") as outFile: outFile.write(line+"\n")
+
+def title(text,before=15,after=15,separator="-",head=2,tail=1):
+    """Prints text in a title-style."""
+    separator = str(separator)
+    line = "\n"*head+separator*before+text+separator*after+"\n"*tail
+    return line
+
+
+###################### MAIN PROGRAM ######################
+
+if __name__=="__main__":
+
+	# User input management
+	arguments = sys.argv[1:]
+	path,start,finish = parseUserArguments(arguments)
+	try: os.mkdir(path)
+	except FileExistsError: pass
+
+	# Loading data from test files
+	dataT = np.loadtxt("output.dat",skiprows=0)     			# Thermodynamic data
+	data = dataT.T                          					# Each parameter in a column
+	t,E,Epot,Ekin,Tinst,P,MSD,p = data      					# Getting each parameter
+
+	# Defining data labels 
+	data_labels = ["E (kJ/mol)","Epot (kJ/mol)","Ekin (kJ/mol)","T (K)","P (Pa)","MSD (A^2)","Pt (kg*m/s)"]
+	data_labels_f = ["E(kJ/mol)","$E_{pot}$(kJ/mol)","$E_{kin}$(kJ/mol)","T(K)","P(Pa)","MSD($\\AA^2$)","$P_T$(kg*m/s)"]
+
+	# Creating output file
+	outFile = "stats_out.dat"
+	if os.path.exists(outFile): os.remove(outFile)
+
+	# Formatted table columns and title
+	titles_format =" {:^23} | " * (4 + 0)
+	data_format =" {:^23} | " + " {:^23.15e} | " * (3 + 0)
+	write("",file=outFile)
+	write("Statistichal parameters for each computed observable:\n",file=outFile)
+	write(titles_format.format("Observable","Average, <x>", "STD, \u03C3", "Autocorrelation time, \u03C4"),file=outFile)
+	write(title("",before=23*4,head=0,tail=0),outFile)
+
+	# Computing Block Averages of diferent data
+	params = []                                     # Initial empty array for optimized fitting parameters
+	for i,xi in enumerate(data[1:]):              	# For each data set (avoiding time)
+		n_tot = len(xi)
+		
+		# Calculate Block Averages (Binning)
+		m_points_i,blockVar_i,blockMean_i = blockAverage(xi[start:],maxBlockSize=int(n_tot/100))
+
+		# Calulate fitting for the Block_STD computed
+		params_i, cov_i = fit(fit_function,m_points_i,np.sqrt(blockVar_i))      # Fitting --> Getting optimized params
+		x_m = np.linspace(m_points_i[0],m_points_i[-1])                         # linspace for the fitted function (smoother)
+		fitted_sigma = fit_function(x_m,*params_i)                              # values for the fitted function
+		params.append(params_i)
+		
+		# Computing statistichal parameters
+		mean = blockMean_i.mean()                                               # Calculation of the total mean (average of BockMeans)
+		std = fitted_sigma[-1]                                                  # Correlated STD will be the one at large BlockSizes (m) (last values of fitted function, plateau)
+		tau = params_i[-1]														# Autocorrelation time (from fitting)
+		
+		# Writing and Plotting results
+		observable_label = data_labels[i].split("(")[0].strip()
+		write(data_format.format(data_labels[i],mean,std,tau),file=outFile)
+		plotBlockAverage(m_points_i,blockVar_i,blockMean_i,fit_params=params_i,label=data_labels_f[i], save_name=f"BlockAverage_{observable_label}.png")
+
+	# Difussion Coeffitient (linear fit of MSD to y= ax + b)
+	(a,b),D_residual,extra1,extra2,extra3 = np.polyfit(t[start:finish],MSD[start:finish],deg=1,full=True)
+	D = a/6  * 1e12 /1e20 # (Diffusion coeffitient)
+	write(f"\nEstimated Difussion Coefitient (A^2/ps): D = {D}",file=outFile)
+
+	# Writing fitting parameters
+	write("\n",file=outFile)
+	write("Fitting parameters for block STD fitting to the function f(x) = a-b*exp(-x/tau):\n",file=outFile)
+	write(titles_format.format("Observable","a", "b", "\u03C4"),file=outFile)
+	write(title("",before=23*4,head=0,tail=0),outFile)
+	for i,param in enumerate(params):
+		write(data_format.format(data_labels[i], *param),file=outFile)
+
+
+	# Ending
+	tf = cpu_time.time()
+	write(f"\n\nProcess finished in {tf-to:.2f}s.\n",file=outFile)
+	write("Have a nice day :) \n",file=outFile)

--- a/scripts/visualization.py
+++ b/scripts/visualization.py
@@ -105,6 +105,8 @@ if __name__ == "__main__":
     data = dataT.T                          					# Each parameter in a column
     t,E,Epot,Ekin,Tinst,P,MSD,p = data      					# Getting each parameter
     
+    # dataRDF = np.loadtxt("RDF_out.dat").T
+    # r,RDF = dataRDF
 
     # Energies Plot
     makePlot(t,[Ekin,Epot,E],["r","b","k"],["$E_{kin}$","$E_{pot}$","$E$"],

--- a/scripts/visualization.py
+++ b/scripts/visualization.py
@@ -1,0 +1,158 @@
+"""
+Script for plotting the results of the output data from the MD runs.
+Plots Energies, Temperature, Pressure, MSD and RDF.
+
+Use: $ python3 visualization.py path start finish
+although if any arguments is not present chooses from the default 
+path, start,finish = ./plots/, 0,-1 
+
+Diego Ontiveros
+"""
+
+import os
+import sys
+import time as cpu_time
+
+import numpy as np
+import matplotlib.pyplot as plt
+to = cpu_time.time()
+
+
+def parseUserArguments(arguments):
+    """Parses the user input for the script."""
+
+    path = "./plots/"
+    start,finish = None,None
+
+    for i,arg in enumerate(arguments):
+        try: arguments[i] = int(arg)
+        except ValueError: pass
+
+    # When no inputs are given, stay with default
+    if len(arguments) == 0: pass
+
+    # When 1 argument is given see if its the path or start
+    elif len(arguments) == 1:
+        try: start = int(arguments[0])
+        except ValueError: path = arguments[0]
+
+    # When 2 arguments are given see if they are path+s or s+f
+    elif len(arguments) == 2:
+        if isinstance(arguments[0],str): path,start = arguments
+        elif isinstance(arguments[1],str): start,path = arguments
+        else: start,finish = arguments
+
+    # When 3 arguments are given see where the path is
+    elif len(arguments) == 3:
+        if isinstance(arguments[0],str): path,start,finish = arguments
+        elif isinstance(arguments[0],int): start, finish, path = arguments
+    
+    return path,start,finish
+
+
+def makePlot(t,lines:list[np.ndarray],colours:list[str],labels:list[str],file_name:str,start=None,finish=None,save=True,**kwargs):
+    """General function to make a plot of output line (or lines) and save the image.
+
+    Parameters
+    ----------
+    `t` : x array of the plot. np.array.
+    `lines` : List with the arrays of the lines to plot. When only one line, accepts a np.array.
+    `colours` : List with the colours of each line. When only one line, accepts a string.
+    `labels` : List with the labels of each line. When only one line, accepts a string.
+    `file_name` : Name of the output image.
+    `start` : Optional. Index from which iteration to start the plot. By default None.
+    `finish` : Optional. Index at which iteration the plot ends. By default None.
+    `save` : Optional. Bool to save or not the figure. By default True.
+    `**kwargs`: Optional. General plot wkargs (xylim,figsize,xylabels).
+
+    Returns
+    -------
+    `fig` : Drawn Figure.
+    `ax` : Drawn Axis.
+    """
+
+    if not isinstance(lines,list): lines, colours, labels = [lines],[colours],[labels]
+
+    fig,ax = plt.subplots(figsize=kwargs.get("figzise",(7,7)))
+
+    for line,colour,label in zip(lines,colours,labels):
+        plt.plot(t[start:finish],line[start:finish],c=colour,lw=0.5,label=label)
+
+    ax.set_xlim(kwargs.get("xlim",(t[start:finish][0],t[start:finish][-1])))
+    ax.set_ylim(kwargs.get("ylim",(None,None)))
+    ax.set_xlabel(kwargs.get("xlabel","Time (ps)"))
+    ax.set_ylabel(kwargs.get("ylabel",None))
+    ax.legend()
+    fig.tight_layout()
+    if save: fig.savefig(path+file_name,dpi=600)
+
+    return fig,ax
+
+
+############################### MAIN PROGRAM ###############################
+
+if __name__ == "__main__":
+
+    # User input management
+    arguments = sys.argv[1:]
+    path,start,finish = parseUserArguments(arguments)
+    try: os.mkdir(path)
+    except FileExistsError: pass
+    print("\nMaking Plots...")
+    
+    # Loading data from files
+    dataT = np.loadtxt("output.dat",skiprows=0)     			# Thermodynamic data
+    data = dataT.T                          					# Each parameter in a column
+    t,E,Epot,Ekin,Tinst,P,MSD,p = data      					# Getting each parameter
+    
+
+    # Energies Plot
+    makePlot(t,[Ekin,Epot,E],["r","b","k"],["$E_{kin}$","$E_{pot}$","$E$"],
+            file_name="energies.png",
+            xlabel="Time (ps)", ylabel="Energy (kJ/mol)")
+
+    # Temperature Plot
+    makePlot(t,Tinst,"r","$T_{inst}$",
+            file_name="temperature.png",
+            xlabel="Time (ps)", ylabel="Temperature (K)")
+
+    # Pressure Plot
+    makePlot(t,P,"purple","P",
+            file_name="pressure.png",
+            xlabel="Time (ps)",ylabel="Pressure (Pa)")
+
+    # MSD Plot
+    start,finish = None,None
+    figMSD,axMSD = makePlot(t,MSD,"green","MSD",
+            file_name="MSD.png", save=False,
+            xlabel="Time (ps)", ylabel="MSD ($\AA^2$)")
+    a,b = np.polyfit(t[start:finish],MSD[start:finish],deg=1)     # linear fit to ax + b
+    D = a/6  * 1e12 /1e20 # (Diffusion coeffitient)
+    #! Show D in plot?
+
+    axMSD.plot(t[start:finish],a*t[start:finish]+b,"k:",alpha=0.75)
+    figMSD.savefig(path+"MSD.png",dpi=600)
+
+    # RDF Plot
+    # makePlot(r,RDF,"red","RDF",
+    #          file_name="RDF.png",
+    #          xlabel="RDF",ylabel="r ($\AA$)")
+    # 
+
+
+    # Trajectory #!(make this user input?)
+    make_trajectory = False
+    if make_trajectory:
+        from ase import io
+        if os.path.exists("trajectory.xyz"):
+            try:
+                frames = io.read("trajectory.xyz", index=":")
+                io.write(path+"trajectory.gif", frames, interval=50)
+                print(f"Trajectory.gif was created.")
+
+            except:
+                print("ase could not read the trajectory.xyz file. Make sure the format is correct (as .xyz).")
+        else: print("Structure trajectory not found. Make sure the file was created.")
+
+tf = cpu_time.time()
+print(f"\nProcess finished in {tf-to:.2f}s.\n")

--- a/src/initialization.f90
+++ b/src/initialization.f90
@@ -26,14 +26,14 @@ module initialization
         
 
         !# Dejo numeros real*4 porque sino hay error y la M da uno menor. Round?->INT
-        L = (N/density)**(1.d0/3.d0)
-        if (cell=="sc") then; M = int((N)**(1./3.),kind=i64)
-        else if (cell=="fcc") then; M = int((N/4.)**(1./3.), kind=i64)
-        else if (cell=="bcc") then; M = int((N/2.)**(1./3.), kind=i64)
+        L = (real(N,kind=dp)/density)**(1.d0/3.d0)
+        if (cell=="sc") then; M = int((real(N,kind=dp))**(1.d0/3.d0),kind=i64)
+        else if (cell=="fcc") then; M = int((real(N,kind=dp)/4.d0)**(1.d0/3.d0), kind=i64)
+        else if (cell=="bcc") then; M = int((real(N,kind=dp)/2.d0)**(1.d0/3.d0), kind=i64)
         else; print*, "Select a valid initial position: sc, bcc, fcc."
         end if
     
-        a = L/M            ! Lattice parameter
+        a = L/real(M, kind=dp)            ! Lattice parameter
         
     end subroutine getInitialParams
     
@@ -115,7 +115,7 @@ module initialization
             do j=0,M-1_i64
                 do k=0,M-1_i64
                     do at=1,size(ucell, dim=2,kind=i64)
-                        r(:, p) = ucell(:,at) + (/i,j,k/)
+                        r(:, p) = ucell(:,at) + (/real(i,kind=dp),real(j,kind=dp),real(k,kind=dp)/)
                         !p = at + (k+(j+i*M)*M)*size(ucell, dim=2, kind=i64) 
                         p = p + 1_i64 
                     end do

--- a/src/initialization.f90
+++ b/src/initialization.f90
@@ -53,6 +53,7 @@ module initialization
         double precision, intent(in) :: lj_epsilon,lj_sigma,mass
         double precision, intent(inout) :: density,dt
         double precision :: ru_time,ru_dens
+        double precision, parameter :: Na = 6.0221408d23
 
         ! Conversion factors between reduced and real units
         ru_time = sqrt(mass*(lj_sigma*1d-10)**2_i64 / (lj_epsilon*1d6))*1d12    ! t in picoseconds

--- a/src/initialization.f90
+++ b/src/initialization.f90
@@ -9,14 +9,16 @@ module initialization
 
     subroutine getInitialParams(cell,N,density,M,L,a)
         ! Returns the initial cell parameters of the simulation.
-        ! Inputs: 
-        ! cell: String with the name of the cell (sc, bcc, fcc).
-        ! N : Number of particles.
-        ! density : Density of the system.
-        ! Outputs:
-        ! M : Number of cells in one direction.
-        ! L : Length of the simulation box.
-        ! a : Lattice parameter of the unit cell (L/M).
+        !
+        ! Args: 
+        !   cell    (CHARACTER) : String with the name of the cell (sc, bcc, fcc).
+        !   N       (INT64)     : Number of particles.
+        !   density (REAL64)    : Density of the system.
+        !
+        ! Returns:
+        !   M       (INT64)     : Number of cells in one direction.
+        !   L       (REAL64)    : Length of the simulation box.
+        !   a       (REAL64)    : Lattice parameter of the unit cell (L/M).
 
         character(*), intent(in) :: cell
         integer(kind=i64), intent(in) :: N
@@ -24,8 +26,6 @@ module initialization
         integer(kind=i64), intent(out) :: M
         double precision, intent(out) :: L, a
         
-
-        !# Dejo numeros real*4 porque sino hay error y la M da uno menor. Round?->INT
         L = (real(N,kind=dp)/density)**(1.d0/3.d0)
         if (cell=="sc") then; M = int((real(N,kind=dp))**(1.d0/3.d0),kind=i64)
         else if (cell=="fcc") then; M = int((real(N,kind=dp)/4.d0)**(1.d0/3.d0), kind=i64)
@@ -36,15 +36,45 @@ module initialization
         a = L/real(M, kind=dp)            ! Lattice parameter
         
     end subroutine getInitialParams
-    
 
+
+    subroutine changeIUnits(lj_epsilon,lj_sigma,mass,density,dt)
+        ! Changes user Input units to reduced units.
+        !
+        ! Args:
+        !   lj_epsilon  (REAL64) : Lennard Jones epsilon parameter for the gas (in kJ/mol)
+        !   lj_sigma    (REAL64) : Lennard Jones sigma parameter for the gas (in Ang)
+        !   mass        (REAL64) : Molar Mass of the gas (g/mol)
+        !
+        ! Inout:
+        !   density     (REAL64) : Density of the system (in g/mL)
+        !   dt          (REAL64) :  Time-step of the simulation (in ps)
+
+        double precision, intent(in) :: lj_epsilon,lj_sigma,mass
+        double precision, intent(inout) :: density,dt
+        double precision :: ru_time,ru_dens
+
+        ! Conversion factors between reduced and real units
+        ru_time = sqrt(mass*(lj_sigma*1d-10)**2_i64 / (lj_epsilon*1d6))*1d12    ! t in picoseconds
+        ru_dens = 1d24 * mass / (Na*lj_sigma**3_i64)                            ! density in g/mL
+
+        density = density / ru_dens
+        dt = dt / ru_time
+
+    end subroutine changeIUnits
+
+   
     subroutine initializePositions(M,a,r,cell)
         ! Chooses and runs the specified initial position.
         ! For the given cell, selects the unit cell matrix and initializes the positions.
-        ! M : Number of cells in one direction.
-        ! a : Lattice parameter of the unit cell (L/M)
-        ! cell: String with the name of the cell (sc, bcc, fcc).
-        ! r : 3xN Positions matrix.  
+        !
+        ! Args:
+        !   M       (INT64)       : Number of cells in one direction.
+        !   a       (REAL64)      : Lattice parameter of the unit cell (L/M)
+        !   cell    (CHARACTER)   : String with the name of the cell (sc, bcc, fcc).
+        !
+        ! Inout:
+        !   r       (REAL64[3,N]) : 3xN Positions matrix.  
 
         implicit none
         integer(kind=i64), intent(in) :: M
@@ -52,7 +82,6 @@ module initialization
         character(*), intent(in) :: cell
         double precision, intent(inout),dimension(:,:) :: r
         double precision, allocatable, dimension(:,:) :: ucell
-
 
         if ((index(cell,"fcc")==1) .OR. (index(cell,"FCC")==1))  then
             allocate(ucell(3,4))
@@ -76,9 +105,13 @@ module initialization
 
     subroutine initializeVelocities(T,v,init_vel)
         ! Chooses and runs the specified initial velocities.
-        ! T : Temperature.
-        ! v : 3xN Velocity matrix.
-        ! init_vel: String with the initialization method (bimodal, zero).
+        !
+        ! Args:
+        !   T           (REAL64)      : Temperature.
+        !   init_vel    (CHARACTER)   : String with the initialization method (bimodal, zero).
+        !
+        ! Inout:
+        !   v           (REAL64[3,N]) : 3xN Velocity matrix.
 
         double precision,intent(in) :: T
         double precision,intent(inout),dimension(:,:) :: v
@@ -98,10 +131,14 @@ module initialization
 
     subroutine initializeGeneral(M,a,ucell,r)
         ! Initializes the position matrix for a given unit cell.
-        ! M : Number of cells in one direction.
-        ! a : Lattice parameter of the unit cell (L/M)
-        ! ucell: Matrix with the unit cell atom's positions.
-        ! r : 3xN Positions matrix.  
+        !
+        ! Args:
+        !   M       (INT64)       : Number of cells in one direction.
+        !   a       (REAL64)      : Lattice parameter of the unit cell (L/M).
+        !   ucell   (REAL[:,:])   : Matrix with the unit cell atom's positions.
+        !
+        ! Inout:
+        !   r       (REAL64[3,N]) : 3xN Positions matrix.   
             
         implicit none
         integer(kind=i64), intent(in) :: M
@@ -129,8 +166,12 @@ module initialization
 
     subroutine initBimodal(T,v)
         ! Initial velocities as Bimodal distribution.
-        ! T : Temperature.
-        ! v : 3xN Velocities matrix.
+        !
+        ! Args:
+        !   T           (REAL64)      : Temperature.
+        !
+        ! Inout:
+        !   v           (REAL64[3,N]) : 3xN Velocity matrix.
 
         implicit none
         double precision,intent(in) :: T

--- a/src/main.f90
+++ b/src/main.f90
@@ -1,8 +1,7 @@
 program main
     use, intrinsic :: iso_fortran_env, only: DP => real64, I64 => int64, i32 => int32, input_unit, output_unit, error_unit
     ! Module definitions
-    use            :: initialization, only: getInitialParams, initializePositions, initializeVelocities, initializeGeneral, &
-    initBimodal
+    use            :: initialization, only: changeIUnits, getInitialParams, initializePositions, initializeVelocities
     use            :: testing
     use            :: readers_m,      only: read_nml
     implicit none
@@ -65,6 +64,7 @@ program main
     status='replace', form='formatted')
 
     ! ~ Initialization of the system ~
+    call changeIUnits(lj_epsilon,lj_sigma,mass,density,dt)
     call getInitialParams(cell_type,N,density,M,L,a)
     call initializePositions(M,a,r,cell_type)
     call initializeVelocities(T,v,init_vel)

--- a/src/pbc.f90
+++ b/src/pbc.f90
@@ -24,8 +24,8 @@ contains
         ! local variables
         integer(kind=i64)                               :: i, j, N, M
 
-        N = size(positions(1,:))
-        M = size(positions(:,1))
+        N = size(positions(1,:),kind=i64)
+        M = size(positions(:,1),kind=i64)
 
         do j = 1, M
             do i = 1, N

--- a/src/writers_mod.f90
+++ b/src/writers_mod.f90
@@ -1,0 +1,73 @@
+module writers_m
+    ! Module for writing the data to output files.
+    ! Contains subroutines to write the system data and positions.
+
+    use, intrinsic :: iso_fortran_env, only: dp => real64, i64 => int64, error_unit
+    implicit none
+
+    contains
+
+    subroutine writeSystem(unit,lj_epsilon,lj_sigma,mass, time,E,Epot,Ekin,T,press,MSD,momentum)
+        ! Writes system data to the main output file.Changes reduced units 
+        ! used in simulation to real units.
+        ! unit : file unit to write on.
+        ! lj_epsilon : Lennard Jones epsilon parameter for the gas (in kJ/mol)
+        ! lj_sigma : Lennard Jones sigma parameter for the gas (in Ang)
+        ! mass : Molar Mass of the gas (g/mol)
+        
+        integer(kind=i64), intent(in) :: unit
+        double precision, intent(in) :: lj_epsilon,lj_sigma,mass
+        double precision, intent(in) :: time,E,Epot,Ekin,T,press,MSD,momentum
+        double precision :: time_out,E_out,Epot_out,Ekin_out,T_out,press_out,MSD_out,momentum_out
+        double precision :: ru_time,ru_dens,ru_dist,ru_temp,ru_E,ru_press,ru_vel,ru_mom
+        double precision, parameter :: Na = 6.0221408d23
+        double precision, parameter :: kb = 1.380649d-23
+
+        ! Conversion factors between reduced and real units
+        ru_time = sqrt(mass*(lj_sigma*1d-10)**2_i64 / (lj_epsilon*1d6))     ! t in seconds
+        ru_dist = lj_sigma                                                  ! distance in Ang
+        ru_dens = 1d24 * mass / (Na*lj_sigma**3_i64)                        ! density in g/mL
+        ru_E = lj_epsilon                                                   ! energy in kJ/mol
+        ru_press = 1d3*lj_epsilon/((lj_sigma*1d-10)**3_i64 * Na)            ! pressure in Pa
+        ru_temp = 1d3*lj_epsilon/(kb*Na)                                    ! temperature in K
+        ru_vel = ru_dist/ru_time *1d-10                                     ! velocity in Ang/s
+        ru_mom = 1d-3*(mass/Na)*ru_vel*1d-10                                ! linear momentum in kg*m/s
+
+        ! Multiplying the reduced value with its correspondent conversion factor
+        time_out = time * ru_time
+        E_out = E * ru_E
+        Epot_out = Epot * ru_E
+        Ekin_out = Ekin * ru_E
+        T_out = T * ru_temp
+        press_out = press * ru_press
+        MSD_out = MSD * ru_dist**2_i64
+        momentum_out = momentum * ru_mom
+
+        ! Writes to output file (coumun style)
+        write(unit,*) time_out,E_out,Epot_out,Ekin_out,T_out,press_out,MSD_out,momentum_out
+
+    end subroutine writeSystem
+
+
+    subroutine writePositions(r,unit)
+        ! Writes current position in the specified file (XYZ format).
+        ! In a loop, writes trajectory.
+        ! r : 3xN Positions matrix. 
+        ! unit : file unit to write on.
+        implicit none
+        double precision, intent(in),dimension(:,:) :: r
+        integer(kind=i64), intent(in) :: unit
+        integer(kind=i64) :: i, N
+
+        N = size(r, dim=2,kind=i64)
+
+        write(unit,*) N
+        write(unit,*)
+        do i= 1,N
+            write(unit,*) "Ar", r(:,i)
+        end do
+
+    end subroutine writePositions
+
+
+end module writers_m

--- a/src/writers_mod.f90
+++ b/src/writers_mod.f90
@@ -10,6 +10,7 @@ module writers_m
     subroutine writeSystem(unit,lj_epsilon,lj_sigma,mass, time,E,Epot,Ekin,T,press,MSD,momentum)
         ! Writes system data to the main output file. Changes reduced units 
         ! used in simulation to real units.
+        !
         ! Args:
         !   unit        (INT64)  : File unit to write on.
         !   lj_epsilon  (REAL64) : Lennard Jones epsilon parameter for the gas (in kJ/mol).
@@ -54,6 +55,7 @@ module writers_m
     subroutine writePositions(r,unit)
         ! Writes current position in the specified file (XYZ format).
         ! In a loop, writes trajectory.
+        !
         ! Args:
         !   r       (REAL64[3,N]) : 3xN Positions matrix.  
         !   unit    (INT64)       : File unit to write on.

--- a/src/writers_mod.f90
+++ b/src/writers_mod.f90
@@ -8,12 +8,14 @@ module writers_m
     contains
 
     subroutine writeSystem(unit,lj_epsilon,lj_sigma,mass, time,E,Epot,Ekin,T,press,MSD,momentum)
-        ! Writes system data to the main output file.Changes reduced units 
+        ! Writes system data to the main output file. Changes reduced units 
         ! used in simulation to real units.
-        ! unit : file unit to write on.
-        ! lj_epsilon : Lennard Jones epsilon parameter for the gas (in kJ/mol)
-        ! lj_sigma : Lennard Jones sigma parameter for the gas (in Ang)
-        ! mass : Molar Mass of the gas (g/mol)
+        ! Args:
+        !   unit        (INT64)  : File unit to write on.
+        !   lj_epsilon  (REAL64) : Lennard Jones epsilon parameter for the gas (in kJ/mol).
+        !   lj_sigma    (REAL64) : Lennard Jones sigma parameter for the gas (in Ang).
+        !   mass        (REAL64) : Molar Mass of the gas (g/mol).
+        !   *args       (REAL64) : Simulation params to write. (time,E,Epot,Ekin,T,press,MSD,momentum)
         
         integer(kind=i64), intent(in) :: unit
         double precision, intent(in) :: lj_epsilon,lj_sigma,mass
@@ -52,8 +54,9 @@ module writers_m
     subroutine writePositions(r,unit)
         ! Writes current position in the specified file (XYZ format).
         ! In a loop, writes trajectory.
-        ! r : 3xN Positions matrix. 
-        ! unit : file unit to write on.
+        ! Args:
+        !   r       (REAL64[3,N]) : 3xN Positions matrix.  
+        !   unit    (INT64)       : File unit to write on.
         implicit none
         double precision, intent(in),dimension(:,:) :: r
         integer(kind=i64), intent(in) :: unit
@@ -64,7 +67,7 @@ module writers_m
         write(unit,*) N
         write(unit,*)
         do i= 1,N
-            write(unit,*) "Ar", r(:,i)
+            write(unit,*) "A", r(:,i)
         end do
 
     end subroutine writePositions


### PR DESCRIPTION
- Added a `scripts/` folder for the Stats and Visualization Python scripts. (Still to test well when outputs are available)
    - stats.py : Computes average, STD and autocorrelation time with Block Average method. --> Output file + sigma vs. m plots
    - visualization.py : Plots time series of data, RDF and a GIF of the trajectory.

- Added `writers_mod.f90` module for writing system information and trajectory/positions to output file.
    - Changes the reduced units used in the simulation to real units.

- Added `changeIUnits` subroutinein the initialization, that changes user density and dt (real units) to reduced ones so that the simulation can be run in reduced units.

- Minor documentation/comment changes and/or syntax/warning errors.