### PR TITLE
Update broadcast problems and Verlet list updates

### DIFF
--- a/paralel/src/initialization.f90
+++ b/paralel/src/initialization.f90
@@ -108,7 +108,7 @@ module initialization
         k = 0
         do I = 1, numproc
             ! The extra particles (if any) will go to the first counts
-            if (I < chunk_extra+1) then
+            if (I > (numproc - chunk_extra)) then
                 sendcounts(I) = chunk + 1
             else
                 sendcounts(I) = chunk

--- a/paralel/src/main.f90
+++ b/paralel/src/main.f90
@@ -104,8 +104,8 @@ program main
     call MPI_Bcast(T, 1, MPI_DOUBLE_PRECISION, MASTER, MPI_COMM_WORLD, ierror)
     
     ! CHARACTER broadcasting
-    !call MPI_Bcast(cell_type, 1, MPI_CHAR, MASTER, MPI_COMM_WORLD, ierror)
-    !call MPI_Bcast(init_vel, 1, MPI_CHAR, MASTER, MPI_COMM_WORLD, ierror)
+    call MPI_Bcast(cell_type, 2048, MPI_CHARACTER, MASTER, MPI_COMM_WORLD, ierror)
+    call MPI_Bcast(init_vel, 2048, MPI_CHARACTER, MASTER, MPI_COMM_WORLD, ierror)
 
     ! ~ Memmory allocation ~
     allocate(r(3,N))
@@ -116,8 +116,8 @@ program main
     ! ~ Initialization of the system ~
     call changeIUnits(lj_epsilon,lj_sigma,mass,density,dt,T)
 
-    cell_type = 'sc'
-    init_vel = 'bimodal'
+    !cell_type = 'sc'
+    !init_vel = 'bimodal'
     call getInitialParams(trim(cell_type),N,density,M,L,a)
 
     call divide_positions(taskid,numproc,N, sendcounts,displs,imin,imax,local_N)

--- a/paralel/src/potentials_module.f90
+++ b/paralel/src/potentials_module.f90
@@ -373,4 +373,29 @@ contains
 
     end subroutine compute_vlist
 
+    function update_vlist(displacement, rmax) result(update)
+        ! Author: Marc Alsina <marcalsinac@gmail.com>
+        ! Subroutine that computes if the verlet list has to be updated,
+        ! based on atoms displacements
+
+        ! The actual criteria is to update the verlet list if the displacement
+        ! of each particle is greater or equal half times the buffer cutoff.
+        !
+        ! Args:
+        !   displacement (REAL64[3,N]): Displacement of each atom
+        !   rmax         (REAL64)     : Verlet list cutoff
+        !
+        ! Returns:
+        !   update       (LOGICAL)    : Update or not the verlet list
+        implicit none
+        ! In/Out variables
+        real(kind=dp), dimension(3, :), intent(in) :: displacement
+        real(kind=dp), intent(in)                  :: rmax
+        logical                                    :: update
+
+
+        update = any(displacement >= rmax * 0.5_DP)
+    
+    end function update_vlist
+
 end module potential_m

--- a/paralel/src/potentials_module.f90
+++ b/paralel/src/potentials_module.f90
@@ -346,11 +346,11 @@ contains
         np = size(r, dim=2, kind=i64)
         cutoff2 = cutoffv * cutoffv
 
-        pos = 1
+        pos = 1_I64
 
         do i = imin, imax
 
-            nneigh = 0
+            nneigh = 0_I64
 
             do j = 1, np
 
@@ -361,7 +361,7 @@ contains
                 dist2 = rij(1, 1)**2 + rij(2, 1)**2 + rij(3, 1)**2
 
                 if (dist2 <= cutoff2) then
-                    nneigh = nneigh + 1
+                    nneigh = nneigh + 1_I64
                     vlist(pos + nneigh) = j
                 end if
 

--- a/paralel/src/potentials_module.f90
+++ b/paralel/src/potentials_module.f90
@@ -3,7 +3,7 @@ module potential_m
     use            :: periodic_bc,     only: pbc
     implicit none
 
-    public :: calc_pressure, calc_KE, calc_vdw_pbc, calc_vdw_force
+    public :: calc_pressure, calc_KE, calc_vdw_pbc, calc_vdw_force, update_vlist
 
 contains
 
@@ -389,7 +389,7 @@ contains
         !   update       (LOGICAL)    : Update or not the verlet list
         implicit none
         ! In/Out variables
-        real(kind=dp), dimension(3, :), intent(in) :: displacement
+        real(kind=dp), dimension(:, :), intent(in) :: displacement
         real(kind=dp), intent(in)                  :: rmax
         logical                                    :: update
 

--- a/serial/Makefile
+++ b/serial/Makefile
@@ -9,10 +9,10 @@ VPATH=src/
 F_FLAGS=-std=f2018
 
 # Debug related flags:
-COMP_D_FLAGS=-g3 -Og -fbacktrace -Wall -Wextra -pedantic -fcheck=all,no-array-temps -ffpe-trap=invalid,zero,overflow,underflow,denormal -ffpe-summary=all -Wconversion-extra 
+COMP_D_FLAGS=#-g3 -Og -fbacktrace -Wall -Wextra -pedantic -fcheck=all,no-array-temps -ffpe-trap=invalid,zero,overflow,underflow,denormal -ffpe-summary=all -Wconversion-extra 
 
 # Release related flags:
-COMP_R_FLAGS=#-O3 -funroll-loops -ftree-vectorize -finline-functions -flto=2 -fwhole-program -ftree-vectorizer-verbose=7
+COMP_R_FLAGS=-O3 -funroll-loops -ftree-vectorize -finline-functions -flto=2 -fwhole-program -ftree-vectorizer-verbose=7
 
 # ~ LINKING ~
 ## make: Compiles the program.


### PR DESCRIPTION
Few changes:

- Solved a problem with MPI and the broadcasting of Fortran Characters
- Updated the way how the verlet list is being updated, based on atom's displacements
- Added Diego's changes, related to the addition of remanent particles if particles and processors are not multiple